### PR TITLE
Added support for the TabStripPlacement property on the TabControl.

### DIFF
--- a/ToolkitDemo/MainWindow.xaml
+++ b/ToolkitDemo/MainWindow.xaml
@@ -208,11 +208,24 @@
                         <ListBoxItem>Item 14</ListBoxItem>
                     </ListBox>
                 </GroupBox>
+ 
                 <TabControl Margin="5"
                             Width="300"
                             Height="200"
-                            VerticalAlignment="Top">
+                            VerticalAlignment="Top"
+                            TabStripPlacement="{Binding ElementName=TabStripPlacements, Path=SelectedItem.Tag}">
                     <TabItem Header="Page 1">
+                        <plus:SimpleForm Margin="5">
+                            <TextBlock>TabStripPlacement:</TextBlock>
+                            <ListBox Name="TabStripPlacements" SelectedIndex="0">
+                                <ListBoxItem Tag="{x:Static Dock.Top}">Top</ListBoxItem>
+                                <ListBoxItem Tag="{x:Static Dock.Left}">Left</ListBoxItem>
+                                <ListBoxItem Tag="{x:Static Dock.Right}">Right</ListBoxItem>
+                                <ListBoxItem Tag="{x:Static Dock.Bottom}">Bottom</ListBoxItem>
+                            </ListBox>
+                        </plus:SimpleForm>
+                    </TabItem>
+                    <TabItem Header="Page 2">
                         <plus:SimpleForm Margin="5">
                             <CheckBox IsThreeState="True">CheckBox 1</CheckBox>
                             <CheckBox IsChecked="True">CheckBox 2</CheckBox>
@@ -221,9 +234,6 @@
                             <RadioButton GroupName="TestRadioButtons" IsChecked="True">RadioButton 2</RadioButton>
                             <RadioButton GroupName="TestRadioButtons" IsEnabled="False">RadioButton 3</RadioButton>
                         </plus:SimpleForm>
-                    </TabItem>
-                    <TabItem Header="Page 2">
-                        <TextBlock Text="Content 2" />
                     </TabItem>
                     <TabItem Header="Page 2">
                         <GroupBox Header="Contained GroupBox"
@@ -235,6 +245,7 @@
                         <TextBlock Text="You should never read this..." />
                     </TabItem>
                 </TabControl>
+
             </WrapPanel>
         </ScrollViewer>
     </Grid>

--- a/ToolkitDemo/MainWindow.xaml
+++ b/ToolkitDemo/MainWindow.xaml
@@ -207,8 +207,7 @@
                         <ListBoxItem>Item 13</ListBoxItem>
                         <ListBoxItem>Item 14</ListBoxItem>
                     </ListBox>
-                </GroupBox>
- 
+                </GroupBox> 
                 <TabControl Margin="5"
                             Width="300"
                             Height="200"
@@ -245,7 +244,6 @@
                         <TextBlock Text="You should never read this..." />
                     </TabItem>
                 </TabControl>
-
             </WrapPanel>
         </ScrollViewer>
     </Grid>

--- a/WpfPlus/Styles/TabControlStyle.xaml
+++ b/WpfPlus/Styles/TabControlStyle.xaml
@@ -36,6 +36,16 @@
                                     <Setter TargetName="TextBlock" Property="Foreground"
                                             Value="{DynamicResource TabControlTabDisabledForegroundBrush}" />
                                 </Trigger>
+
+                                <Trigger Property="TabStripPlacement" Value="Left">
+                                    <Setter TargetName="Border" Property="Margin" Value="0,0,0,1"/>
+                                    <Setter TargetName="Border" Property="BorderThickness" Value="0,0,0,0"/>
+                                </Trigger>
+
+                                <Trigger Property="TabStripPlacement" Value="Right">
+                                    <Setter TargetName="Border" Property="Margin" Value="0,0,0,1"/>
+                                </Trigger>
+
                             </ControlTemplate.Triggers>
                         </ControlTemplate>
                     </Setter.Value>
@@ -52,15 +62,27 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabControl}">
                     <Grid KeyboardNavigation.TabNavigation="Local">
+                        
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="*" />
+                            <RowDefinition x:Name="TopRow" Height="Auto" />
+                            <RowDefinition x:Name="BottomRow" Height="*" />
                         </Grid.RowDefinitions>
-                        <TabPanel Grid.Row="0"
+
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition x:Name="LeftColumn" Width="*"/>
+                            <ColumnDefinition x:Name="RightColumn" Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        
+                        <TabPanel x:Name="HeaderPanel" 
+                                  Grid.Row="0"
+                                  Grid.Column="0"
                                   IsItemsHost="True"
                                   KeyboardNavigation.TabIndex="1"
                                   Background="Transparent" />
-                        <Border Grid.Row="1"
+                        
+                        <Border x:Name="ContentPanel" 
+                                Grid.Row="1"
+                                Grid.Column="0"
                                 Background="{TemplateBinding Background}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
@@ -72,6 +94,31 @@
                                               ContentSource="SelectedContent" />
                         </Border>
                     </Grid>
+
+                    <ControlTemplate.Triggers>
+                        
+                        <Trigger Property="TabStripPlacement" Value="Bottom">
+                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="1"/>
+                            <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0"/>
+                            <Setter TargetName="TopRow" Property="Height" Value="*"/>
+                            <Setter TargetName="BottomRow" Property="Height" Value="Auto"/>
+                        </Trigger>
+
+                        <Trigger Property="TabStripPlacement" Value="Left">
+                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="1"/>
+                            <Setter TargetName="ContentPanel" Property="Grid.Column" Value="1"/>
+                            <Setter TargetName="LeftColumn" Property="Width" Value="Auto"/>
+                            <Setter TargetName="RightColumn" Property="Width" Value="*"/>
+                        </Trigger>
+
+                        <Trigger Property="TabStripPlacement" Value="Right">
+                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="1"/>
+                            <Setter TargetName="HeaderPanel" Property="Grid.Column" Value="1"/>
+                            <Setter TargetName="LeftColumn" Property="Width" Value="*"/>
+                            <Setter TargetName="RightColumn" Property="Width" Value="Auto"/>
+                        </Trigger>
+
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/WpfPlus/Styles/TabControlStyle.xaml
+++ b/WpfPlus/Styles/TabControlStyle.xaml
@@ -36,16 +36,13 @@
                                     <Setter TargetName="TextBlock" Property="Foreground"
                                             Value="{DynamicResource TabControlTabDisabledForegroundBrush}" />
                                 </Trigger>
-
                                 <Trigger Property="TabStripPlacement" Value="Left">
                                     <Setter TargetName="Border" Property="Margin" Value="0,0,0,1"/>
                                     <Setter TargetName="Border" Property="BorderThickness" Value="0,0,0,0"/>
                                 </Trigger>
-
                                 <Trigger Property="TabStripPlacement" Value="Right">
                                     <Setter TargetName="Border" Property="Margin" Value="0,0,0,1"/>
                                 </Trigger>
-
                             </ControlTemplate.Triggers>
                         </ControlTemplate>
                     </Setter.Value>
@@ -61,25 +58,21 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabControl}">
-                    <Grid KeyboardNavigation.TabNavigation="Local">
-                        
+                    <Grid KeyboardNavigation.TabNavigation="Local">                        
                         <Grid.RowDefinitions>
                             <RowDefinition x:Name="TopRow" Height="Auto" />
                             <RowDefinition x:Name="BottomRow" Height="*" />
                         </Grid.RowDefinitions>
-
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition x:Name="LeftColumn" Width="*"/>
                             <ColumnDefinition x:Name="RightColumn" Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        
+                        </Grid.ColumnDefinitions>                        
                         <TabPanel x:Name="HeaderPanel" 
                                   Grid.Row="0"
                                   Grid.Column="0"
                                   IsItemsHost="True"
                                   KeyboardNavigation.TabIndex="1"
-                                  Background="Transparent" />
-                        
+                                  Background="Transparent" />                        
                         <Border x:Name="ContentPanel" 
                                 Grid.Row="1"
                                 Grid.Column="0"
@@ -94,30 +87,25 @@
                                               ContentSource="SelectedContent" />
                         </Border>
                     </Grid>
-
-                    <ControlTemplate.Triggers>
-                        
+                    <ControlTemplate.Triggers>                        
                         <Trigger Property="TabStripPlacement" Value="Bottom">
                             <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="1"/>
                             <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0"/>
                             <Setter TargetName="TopRow" Property="Height" Value="*"/>
                             <Setter TargetName="BottomRow" Property="Height" Value="Auto"/>
                         </Trigger>
-
                         <Trigger Property="TabStripPlacement" Value="Left">
                             <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="1"/>
                             <Setter TargetName="ContentPanel" Property="Grid.Column" Value="1"/>
                             <Setter TargetName="LeftColumn" Property="Width" Value="Auto"/>
                             <Setter TargetName="RightColumn" Property="Width" Value="*"/>
                         </Trigger>
-
                         <Trigger Property="TabStripPlacement" Value="Right">
                             <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="1"/>
                             <Setter TargetName="HeaderPanel" Property="Grid.Column" Value="1"/>
                             <Setter TargetName="LeftColumn" Property="Width" Value="*"/>
                             <Setter TargetName="RightColumn" Property="Width" Value="Auto"/>
                         </Trigger>
-
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
I added support for the `TabStripPlacement` property on the `TabControl`  style so now the tabs can also be placed left, right or below the content. I also changed the ToolkitDemo program to show the effect of the `TabStripPlacement` property values.

Regards,
Peter